### PR TITLE
Refactor/spectral model addendum

### DIFF
--- a/glotaran/builtin/io/yml/yml.py
+++ b/glotaran/builtin/io/yml/yml.py
@@ -7,8 +7,6 @@ from typing import TYPE_CHECKING
 
 import yaml
 
-from glotaran.builtin.io.yml.sanatize import check_deprecations
-from glotaran.builtin.io.yml.sanatize import sanitize_yaml
 from glotaran.io import ProjectIoInterface
 from glotaran.io import load_dataset
 from glotaran.io import load_model
@@ -21,6 +19,8 @@ from glotaran.model import get_megacomplex
 from glotaran.parameter import ParameterGroup
 from glotaran.project import SavingOptions
 from glotaran.project import Scheme
+from glotaran.utils.sanitize import check_deprecations
+from glotaran.utils.sanitize import sanitize_yaml
 
 if TYPE_CHECKING:
     from glotaran.project import Result

--- a/glotaran/parameter/parameter.py
+++ b/glotaran/parameter/parameter.py
@@ -113,7 +113,7 @@ class Parameter(_SupportsArray):
             param.value = value
 
         else:
-            values = _sanatize_parameter_list(value)
+            values = _sanitize_parameter_list(value)
             param.label = _retrieve_from_list_by_type(values, str, label)
             param.value = float(_retrieve_from_list_by_type(values, (int, float), 0))
             options = _retrieve_from_list_by_type(values, dict, None)
@@ -489,7 +489,7 @@ def _log_value(value: float):
 _match_scientific = re.compile(r"[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)")
 
 
-def _sanatize_parameter_list(li: list) -> list:
+def _sanitize_parameter_list(li: list) -> list:
     for i, value in enumerate(li):
         if isinstance(value, str) and _match_scientific.match(value):
             li[i] = float(value)

--- a/glotaran/parameter/parameter.py
+++ b/glotaran/parameter/parameter.py
@@ -9,6 +9,8 @@ import asteval
 import numpy as np
 from numpy.typing._array_like import _SupportsArray
 
+from glotaran.utils.sanitize import sanitize_parameter_list
+
 if TYPE_CHECKING:
     from typing import Any
 
@@ -113,7 +115,7 @@ class Parameter(_SupportsArray):
             param.value = value
 
         else:
-            values = _sanitize_parameter_list(value)
+            values = sanitize_parameter_list(value)
             param.label = _retrieve_from_list_by_type(values, str, label)
             param.value = float(_retrieve_from_list_by_type(values, (int, float), 0))
             options = _retrieve_from_list_by_type(values, dict, None)
@@ -483,18 +485,6 @@ def _log_value(value: float):
     if value == 1:
         value += 1e-10
     return np.log(value)
-
-
-# A reexp for ONLY matching scientific
-_match_scientific = re.compile(r"[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)")
-
-
-def _sanitize_parameter_list(li: list) -> list:
-    for i, value in enumerate(li):
-        if isinstance(value, str) and _match_scientific.match(value):
-            li[i] = float(value)
-
-    return li
 
 
 def _retrieve_from_list_by_type(li: list, t: type | tuple[type, ...], default: Any):

--- a/glotaran/utils/regex.py
+++ b/glotaran/utils/regex.py
@@ -1,0 +1,16 @@
+"""Glotaran module with regular expression patterns and functions."""
+import re
+
+
+class RegexPattern:
+    """An 'Enum' of (compiled) regular expression patterns (rp)."""
+
+    # tuple = re.compile(r"(\(.*?,.*?\))")
+    elements_in_string_of_list: re.Pattern = re.compile(r"(\(.+?\)|[-+.\d]+)")
+    group: re.Pattern = re.compile(r"(\(.+?\))")
+    list_with_tuples: re.Pattern = re.compile(r"(\[.+\(.+\).+\])")
+    word: re.Pattern = re.compile(r"[\w]+")
+    number_scientific: re.Pattern = re.compile(r"[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)")
+    number: re.Pattern = re.compile(r"[\d.+-]+")
+    tuple_word: re.Pattern = re.compile(r"(\([.\s\w\d]+?[,.\s\w\d]*?\))")
+    tuple_number: re.Pattern = re.compile(r"(\([\s\d.+-]+?[,\s\d.+-]*?\))")

--- a/glotaran/utils/test/test_sanitize.py
+++ b/glotaran/utils/test/test_sanitize.py
@@ -5,12 +5,12 @@ from typing import NamedTuple
 
 import pytest
 
-from glotaran.builtin.io.yml.sanatize import sanitize_list_with_broken_tuples
+from glotaran.utils.sanitize import sanitize_list_with_broken_tuples
 
 
 class MangledListTestData(NamedTuple):
     input: list[Any]
-    input_sanitized: list[str]
+    input_sanitized: list[str] | str
     output: list[str]
 
 


### PR DESCRIPTION
Adds sanity check for values in the model specification which is in scientific notation style but not recognized as such by the yaml parser.

Moved sanitization to utils package. 